### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/174df9ed-3600-49c6-bbb9-663c101a9946/c6bad4c4-13fc-4654-b658-0c4ff84cefa7/_apis/work/boardbadge/f25513cf-5f20-4152-a6ee-cfd0b539572a)](https://dev.azure.com/aiw-devops/174df9ed-3600-49c6-bbb9-663c101a9946/_boards/board/t/c6bad4c4-13fc-4654-b658-0c4ff84cefa7/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2733](https://dev.azure.com/aiw-devops/174df9ed-3600-49c6-bbb9-663c101a9946/_workitems/edit/2733). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.